### PR TITLE
Fixing overwritten variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,14 +60,16 @@ var _loop = function _loop(command) {
 
     var missing = [];
 
-    if (cfg.type === "both") cfg.params = cfg.params[is_private ? "private" : "public"];
+    var params = cfg.params;
+
+    if (cfg.type === "both") params = params[is_private ? "private" : "public"];
 
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
 
     try {
-      for (var _iterator = cfg.params[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      for (var _iterator = params[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
         var param = _step.value;
 
         if (param.slice(-1) !== "?" && typeof opt[param] === "undefined") missing.push(param);

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,12 @@ for (let command in config.commands) {
 
     let missing = [];
 
-    if (cfg.type === "both")
-      cfg.params = cfg.params[is_private ? "private" : "public"];
+    let params = cfg.params;
 
-    for (let param of cfg.params)
+    if (cfg.type === "both")
+      params = params[is_private ? "private" : "public"];
+
+    for (let param of params)
       if (param.slice(-1) !== "?" && typeof opt[param] === "undefined")
         missing.push(param);
 


### PR DESCRIPTION
This fixes issue described in #3 

Basically the `config.params` was being overwritten in the first call, so the second call would be always broken.
