### PR TITLE
Always include data in error callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,9 +129,9 @@ var _loop = function _loop(command) {
       if (err) {
         cb(err);
       } else if (res.statusCode !== 200) {
-        cb('statusCode ' + res.statusCode);
+        cb('statusCode ' + res.statusCode, data);
       } else if (data && data.error) {
-        cb(data.error);
+        cb(data.error, data);
       } else {
         cb(null, data);
       }


### PR DESCRIPTION
The data argument usually contains useful debugging info that we don't want to lose.
Always return it as the 2nd argument to the cb to maintain consistency while keeping
backward compatibility