### PR TITLE
Add missing API method - returnLendingHistory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -130,6 +130,10 @@ exports.default = {
       type: 'private',
       params: []
     },
+    returnLendingHistory: {
+      type: 'private',
+      params: ['start?', 'end?', 'limit?']
+    },
     toggleAutoRenew: {
       type: 'private',
       params: ['orderNumber']

--- a/src/config.js
+++ b/src/config.js
@@ -126,6 +126,10 @@ export default {
       type: 'private',
       params: []
     },
+    returnLendingHistory: {
+      type: 'private',
+      params: ['start?', 'end?', 'limit?']
+    },
     toggleAutoRenew: {
       type: 'private',
       params: ['orderNumber']


### PR DESCRIPTION
I noticed that the `returnLendingHistory` method is missing, so here it is...