### PR TITLE
remove library responsibility to check for errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,15 +94,7 @@ for (let command in config.commands) {
     dbg({ key, secret, opt, isPrivate, ropt })
 
     request(ropt, (err, res, data) => {
-      if (err) {
-        cb(err)
-      } else if (res.statusCode !== 200) {
-        cb(new Error(`statusCode ${res.statusCode}`))
-      } else if (data && data.error) {
-        cb(data.error)
-      } else {
-        cb(null, data)
-      }
+      cb(err, data, res);
     })
   }
 }


### PR DESCRIPTION
Returning "statusCode XXX" reduces the error information propagated outside of the library thus creating a problem to handle errors, unfortunately, i got into an error message that I can't retrieve because of the current implementation.
Propagating it to outside of the library would allow the application to deal with the error, thus being a standard library that doesn't mutate the error object.
This would break backward compatibility for anyone checking for the "statusCode XXX" message, so would need a major bump in package.json's version.