### PR TITLE
We need to propagate the response and data object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,11 +97,11 @@ for (let command in config.commands) {
       if (err) {
         cb(err)
       } else if (res.statusCode !== 200) {
-        cb(new Error(`statusCode ${res.statusCode}`))
+        cb(new Error(`statusCode ${res.statusCode}`), res, data)
       } else if (data && data.error) {
-        cb(data.error)
+        cb(res, res, data)
       } else {
-        cb(null, data)
+        cb(null, res, data)
       }
     })
   }


### PR DESCRIPTION
There are two main problems here that must be solved:
 1 - When statusCode isn't 200 we only send the status code back and not the "data" object which actually contains the error

For instance when poloniex returns statusCode: 422 and data: error: 'invalid currencyPair' the fact that statusCode isnt 200 makes the library fall into the first "else if" and don't send the "response" neither the data object back to the user so we can't check what poloniex error message actually was.

The correct implementation would actually be: request(ropt, (err, res, data) => { cb(err, data, res) } but that would break backwards compatibility.